### PR TITLE
Prevent setting align param on UIComponent

### DIFF
--- a/lib/UITextField.js
+++ b/lib/UITextField.js
@@ -518,7 +518,7 @@ class UITextField {
 				for (var param in _defaults) {
 					// check for the param first, only errors in IE11/Win7
 					// also check for undefined becusue only checking the key will be false with a 0 value
-					if (U[param] != undefined) {
+					if (U[param] != undefined && param !== 'align') {
 						U[param] = _defaults[param]
 					}
 				}


### PR DESCRIPTION
- prevents "Invalid argument" error in IE11, which occurs when UIComponent attempts to create an HTML element with an "align" param