### PR TITLE
Reimplemented paragraph fit w/ binary search

### DIFF
--- a/lib/UITextField.js
+++ b/lib/UITextField.js
@@ -642,6 +642,31 @@ class UITextField extends UIComponent {
 			}
 		}
 
+		function getOptimalFontSize(low, high, fontSizeCheckFn) {
+			if (fontSizeCheckFn(high)) {
+				return high
+			}
+			
+			if (low >= high) {
+				return high
+			}
+
+			const mid = Math.floor((high + low) / 2)
+
+			if (low === mid || high === mid) {
+				const highFits = fontSizeCheckFn(high)
+				return highFits ? high : low
+			}
+
+			const midFits = fontSizeCheckFn(mid)
+
+			// optimal font size b/w mid and high
+			if (midFits) {
+				return getOptimalFontSize(mid, high, fontSizeCheckFn)
+			}
+			return getOptimalFontSize(low, mid, fontSizeCheckFn)
+		}
+
 		function autoSizeContent() {
 			//temp set it to default for resizing
 			Styles.setCss(_content, {
@@ -651,23 +676,13 @@ class UITextField extends UIComponent {
 			})
 
 			if (_format == 'paragraphFit') {
-				var tempFontSize = _fontSize
+				var optimalFontSize = getOptimalFontSize(_minFontSize, _fontSize, function(fontSize) {
+					U.style.fontSize = fontSize + 'px'
+					resizeTimes++
+					return U.scrollHeight <= U.offsetHeight && U.scrollWidth <= U.offsetWidth
+				})
 
-				// check the height first to allow for word wrap to fit vertically first
-				while (U.scrollHeight > U.offsetHeight) {
-					if (tempFontSize <= _minFontSize) break
-					tempFontSize--
-					U.style.fontSize = tempFontSize + 'px'
-				}
-
-				// then, if it is still overspraying horizontally, shrink again to fit
-				while (U.scrollWidth > U.offsetWidth) {
-					if (tempFontSize <= _minFontSize) break
-					tempFontSize--
-					U.style.fontSize = tempFontSize + 'px'
-				}
-
-				_fontSize = tempFontSize
+				_fontSize = optimalFontSize
 				U.style.fontSize = _fontSize + 'px'
 			} else if (_format == 'inlineFit') {
 				// NOTE - IE wont return correct width/height if the font is smaller than the parent, so using large numbers for ratios
@@ -748,3 +763,4 @@ class UITextField extends UIComponent {
 }
 
 export default UITextField
+


### PR DESCRIPTION
- faster than previous implementation as difference between min and
max font size increases
- based on research from other text fitting procedures

Test results:

- Fitting "This is just a fit paragraph" or "This is a fit-clamp paragraph" within a 100x100 container

minFontSize = 6, fontSize = 50:
old implementation rerenders w/ new font size 29 times
new implementation rerenders: 14

minFontSize = 1, fontSize = 100:
old implementation rerenders: 79
new implementation rerenders: 16

However, w/ minFontSize = 1, fontSize = 10:
old implementation rerenders: 0
new implementation rerenders: 1